### PR TITLE
Updated for HDInsight 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ products:
 
 This is a basic example of using Apache Spark on HDInsight to stream data from Kafka to Azure Cosmos DB. This example uses Spark Structured Streaming and the [Azure Cosmos DB Spark Connector](https://github.com/Azure/azure-cosmosdb-spark). 
 
-This example requires Kafka and Spark on HDInsight 3.6 in the same Azure Virtual Network. It also requires an Azure Cosmos DB SQL API database.
+This example requires Kafka and Spark on HDInsight 4.0 in the same Azure Virtual Network. It also requires an Azure Cosmos DB SQL API database.
 
 __NOTE__: Apache Kafka and Spark are available as two different cluster types. HDInsight cluster types are tuned for the performance of a specific technology; in this case, Kafka and Spark. To use both together, you must create an Azure Virtual network and then create both a Kafka and Spark cluster on the virtual network. 
 
@@ -27,9 +27,9 @@ To create an environment that can be used to run this example, use the __Deploy 
 
 * A virtual network
 
-* Spark on HDInsight 3.6
+* Spark on HDInsight 4.0
 
-* Kafka on HDInsight 3.6
+* Kafka on HDInsight 4.0
 
 * Azure Cosmos DB SQL API database
 

--- a/Stream-data-from-Kafka-to-Cosmos-DB.ipynb
+++ b/Stream-data-from-Kafka-to-Cosmos-DB.ipynb
@@ -1,1 +1,317 @@
-{"nbformat_minor": 2, "cells": [{"source": "# Stream data to from Kafka to Cosmos DB\n\nThis notebook uses Spark Structured Streaming to retrieve data from Kafka on HDInsight and store it into Azure Cosmos DB. It uses the [Azure CosmosDB Spark Connector](https://github.com/Azure/azure-cosmosdb-spark) to write to a Cosmos DB SQL API database. For more information on using the connector, see [https://github.com/Azure/azure-cosmosdb-spark](https://github.com/Azure/azure-cosmosdb-spark)\n\n## To use this notebook\n\nJupyter Notebooks allow you to modify and run the code in this document. To run a section (known as a 'cell',) select it and then use CTRL + ENTER, or select the play button on the toolbar above. Note that each section already has some example output beneath it, so you can see what the results of running a cell will look like.\n\nNOTE: You must run each cell in order, from top to bottom. Running cells out of order can result in an error.\n\n## Requirements\n\n* An Azure Virtual Network\n* A Spark on HDInsight 3.6 cluster, inside the virtual network\n* A Kafka on HDInsight cluster, inside the virtual network\n* A Cosmos DB SQL API database\n\n## Load packages\n\nRun the next cell to load the packages used by this notebook:\n\n* spark-sql-kafka-0-10_2.11, version 2.1.0 - Used to read from Kafka.\n* azure-cosmosdb-spark_2.1.0_2.11, version 1.0.0 - The Spark connector used to communicate with Azure Cosmos DB.\n* azure-documentdb, version 1.15.1 - The DocumentDB SDK. This is used by the connector to communicate with Cosmos DB.", "cell_type": "markdown", "metadata": {}}, {"execution_count": 1, "cell_type": "code", "source": "%%configure -f\n{\n    \"name\":\"Spark-to-Cosmos_DB_Connector\", \n    \"executorMemory\": \"8G\", \n    \"executorCores\": 2, \n    \"numExecutors\":9,\n    \"driverMemory\" : \"2G\",\n    \"conf\": {\n        \"spark.jars.packages\": \"org.apache.spark:spark-sql-kafka-0-10_2.11:2.2.0,com.microsoft.azure:azure-cosmosdb-spark_2.2.0_2.11:1.0.0,com.microsoft.azure:azure-documentdb:1.15.1\", \n        \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.11\"\n    }\n}", "outputs": [{"output_type": "display_data", "data": {"text/plain": "<IPython.core.display.HTML object>", "text/html": "Current session configs: <tt>{u'kind': 'spark', u'name': u'Spark-to-Cosmos_DB_Connector', u'driverMemory': u'2G', u'numExecutors': 9, u'conf': {u'spark.jars.packages': u'org.apache.spark:spark-sql-kafka-0-10_2.11:2.2.0,com.microsoft.azure:azure-cosmosdb-spark_2.2.0_2.11:1.0.0,com.microsoft.azure:azure-documentdb:1.15.1', u'spark.jars.excludes': u'org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.11'}, u'executorCores': 2, u'executorMemory': u'8G'}</tt><br>"}, "metadata": {}}, {"output_type": "display_data", "data": {"text/plain": "<IPython.core.display.HTML object>", "text/html": "<table>\n<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr><tr><td>0</td><td>application_1533323783391_0006</td><td>spark</td><td>busy</td><td><a target=\"_blank\" href=\"http://hn1-spark.d4lt02jpu35epdgcvwdc51hehh.cx.internal.cloudapp.net:8088/proxy/application_1533323783391_0006/\">Link</a></td><td><a target=\"_blank\" href=\"http://wn1-spark.d4lt02jpu35epdgcvwdc51hehh.cx.internal.cloudapp.net:30060/node/containerlogs/container_1533323783391_0006_01_000001/livy\">Link</a></td><td></td></tr></table>"}, "metadata": {}}], "metadata": {"collapsed": false}}, {"source": "## Set the Kafka broker hosts information\n\nIn the next cell, replace YOUR_KAFKA_BROKER_HOSTS with the broker hosts for your Kafka cluster. This is used to write data to the Kafka cluster. To get the broker host information, use one of the following methods:\n\n* From Bash or other Unix shell:\n\n    ```bash\nCLUSTERNAME='the name of your HDInsight cluster'\nPASSWORD='the password for your cluster login account'\ncurl -u admin:$PASSWORD -G \"https://$CLUSTERNAME.azurehdinsight.net/api/v1/clusters/$CLUSTERNAME/services/KAFKA/components/KAFKA_BROKER\" | jq -r '[\"\\(.host_components[].HostRoles.host_name):9092\"] | join(\",\")' | cut -d',' -f1,2\n    ```\n\n* From Azure Powershell:\n\n    ```powershell\n$creds = Get-Credential -UserName \"admin\" -Message \"Enter the HDInsight login\"\n$clusterName = Read-Host -Prompt \"Enter the Kafka cluster name\"\n$resp = Invoke-WebRequest -Uri \"https://$clusterName.azurehdinsight.net/api/v1/clusters/$clusterName/services/KAFKA/components/KAFKA_BROKER\" `\n  -Credential $creds `\n  -UseBasicParsing\n$respObj = ConvertFrom-Json $resp.Content\n$brokerHosts = $respObj.host_components.HostRoles.host_name[0..1]\n($brokerHosts -join \":9092,\") + \":9092\"\n    ```", "cell_type": "markdown", "metadata": {}}, {"execution_count": 2, "cell_type": "code", "source": "// The Kafka broker hosts and topic used to read to Kafka\nval kafkaBrokers=\"YOUR_BROKER_HOSTS\"\nval kafkaTopic=\"tripdata\"\n\nprintln(\"broker and topic set.\")", "outputs": [{"output_type": "stream", "name": "stdout", "text": "Starting Spark application\n"}, {"output_type": "display_data", "data": {"text/plain": "<IPython.core.display.HTML object>", "text/html": "<table>\n<tr><th>ID</th><th>YARN Application ID</th><th>Kind</th><th>State</th><th>Spark UI</th><th>Driver log</th><th>Current session?</th></tr><tr><td>3</td><td>application_1531345171959_0013</td><td>spark</td><td>idle</td><td><a target=\"_blank\" href=\"http://hn1-spark.jcc2uw4e5n3ufjhwet5exykice.dx.internal.cloudapp.net:8088/proxy/application_1531345171959_0013/\">Link</a></td><td><a target=\"_blank\" href=\"http://wn3-spark.jcc2uw4e5n3ufjhwet5exykice.dx.internal.cloudapp.net:30060/node/containerlogs/container_1531345171959_0013_01_000001/livy\">Link</a></td><td>\u2714</td></tr></table>"}, "metadata": {}}, {"output_type": "stream", "name": "stdout", "text": "SparkSession available as 'spark'.\nbroker and topic set."}], "metadata": {"collapsed": false}}, {"source": "## Configure the Cosmos DB connection information\n\nIn the following cell, you must provide the information used to connect to your Cosmos DB. Use the information in [Create a document database using Java and the Azure portal](https://docs.microsoft.com/en-us/azure/cosmos-db/create-sql-api-java) to create a database and collection, then retrieve the endpoint, master key, and preferred region information.\n\n__NOTE__: When following the steps in [Create a document database using Java and the Azure portal](https://docs.microsoft.com/en-us/azure/cosmos-db/create-sql-api-java), you do not need to add sample data to the collection or build the code. You only need to create the database, collection, and retrieve the connection information.\n    ", "cell_type": "markdown", "metadata": {}}, {"execution_count": 3, "cell_type": "code", "source": "// Import Necessary Libraries\nimport org.joda.time._\nimport org.joda.time.format._\n\n// Current version of the connector\nimport com.microsoft.azure.cosmosdb.spark.schema._\nimport com.microsoft.azure.cosmosdb.spark._\nimport com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBSinkProvider\nimport com.microsoft.azure.cosmosdb.spark.config.Config\n\nvar configMap = Map(\n    \"Endpoint\" -> \"YOUR_COSMOSDB_ENDPOINT\",\n    \"Masterkey\" -> \"YOUR_MASTER_KEY\",\n    \"Database\" -> \"kafkadata\",\n    // use a ';' to delimit multiple regions\n    \"PreferredRegions\" -> \"West US;\",\n    \"Collection\" -> \"kafkacollection\"\n)\n\nprintln(\"Cosmos DB configuration set.\")", "outputs": [{"output_type": "stream", "name": "stdout", "text": "Cosmos DB configuration set."}], "metadata": {"collapsed": false}}, {"source": "## Define the schema and source stream\n\nThe following cell creates the stream that reads from Kafka. Data read from Kafka contains several columns. In this case, we only use the `value` column, as it contains the taxi trip data written by the other notebook. To make this data easier to work with, a schema is applied.", "cell_type": "markdown", "metadata": {}}, {"execution_count": 4, "cell_type": "code", "source": "// Import bits useed for declaring schemas and working with JSON data\nimport org.apache.spark.sql._\nimport org.apache.spark.sql.types._\nimport org.apache.spark.sql.functions._\n\n// Define a schema for the data\nval schema = (new StructType).add(\"dropoff_latitude\", StringType).add(\"dropoff_longitude\", StringType).add(\"extra\", StringType).add(\"fare_amount\", StringType).add(\"improvement_surcharge\", StringType).add(\"lpep_dropoff_datetime\", StringType).add(\"lpep_pickup_datetime\", StringType).add(\"mta_tax\", StringType).add(\"passenger_count\", StringType).add(\"payment_type\", StringType).add(\"pickup_latitude\", StringType).add(\"pickup_longitude\", StringType).add(\"ratecodeid\", StringType).add(\"store_and_fwd_flag\", StringType).add(\"tip_amount\", StringType).add(\"tolls_amount\", StringType).add(\"total_amount\", StringType).add(\"trip_distance\", StringType).add(\"trip_type\", StringType).add(\"vendorid\", StringType)\n// Reproduced here for readability\n//val schema = (new StructType)\n//   .add(\"dropoff_latitude\", StringType)\n//   .add(\"dropoff_longitude\", StringType)\n//   .add(\"extra\", StringType)\n//   .add(\"fare_amount\", StringType)\n//   .add(\"improvement_surcharge\", StringType)\n//   .add(\"lpep_dropoff_datetime\", StringType)\n//   .add(\"lpep_pickup_datetime\", StringType)\n//   .add(\"mta_tax\", StringType)\n//   .add(\"passenger_count\", StringType)\n//   .add(\"payment_type\", StringType)\n//   .add(\"pickup_latitude\", StringType)\n//   .add(\"pickup_longitude\", StringType)\n//   .add(\"ratecodeid\", StringType)\n//   .add(\"store_and_fwd_flag\", StringType)\n//   .add(\"tip_amount\", StringType)\n//   .add(\"tolls_amount\", StringType)\n//   .add(\"total_amount\", StringType)\n//   .add(\"trip_distance\", StringType)\n//   .add(\"trip_type\", StringType)\n//   .add(\"vendorid\", StringType)\n\n// Read from the Kafka stream source\nval kafka = spark.readStream.format(\"kafka\").option(\"kafka.bootstrap.servers\", kafkaBrokers).option(\"subscribe\", kafkaTopic).option(\"startingOffsets\",\"earliest\").load()\n\n// Select the value of the Kafka message and apply the trip schema to it\nval taxiData = kafka.select(\n    from_json(col(\"value\").cast(\"string\"), schema) as \"trip\")\n\n// The output of this cell is similar to the following value:\n// taxiData: org.apache.spark.sql.DataFrame = [trip: struct<dropoff_latitude: string, dropoff_longitude: string ... 18 more fields>]", "outputs": [{"output_type": "stream", "name": "stdout", "text": "taxiData: org.apache.spark.sql.DataFrame = [trip: struct<dropoff_latitude: string, dropoff_longitude: string ... 18 more fields>]"}], "metadata": {"collapsed": false}}, {"source": "## Write the data to Cosmos DB\n\nThe following cell selects the trip data from the stream and writes it to Cosmos DB. This is the data structure that was created in the previous cell by applying a schema to the value data retrieved from kafka.\n\nThis stream only runs for 10 seconds (10000ms). Please make sure that the Stream-taxi-data-to-Kafka notebook is actively streaming data into Kafka during this time.", "cell_type": "markdown", "metadata": {"collapsed": false}}, {"execution_count": 5, "cell_type": "code", "source": "taxiData.select(\"trip\").writeStream.format(classOf[CosmosDBSinkProvider].getName).outputMode(\"append\").options(configMap).option(\"checkpointLocation\", \"cosmoscheckpointlocation\").start.awaitTermination(10000)\nprintln(\"Stream finished.\")", "outputs": [{"output_type": "stream", "name": "stdout", "text": "Stream finished."}], "metadata": {"collapsed": false}}, {"source": "## To verify that data is in Cosmos DB\n\nIn the [Azure portal](https://portal.azure.com), select your Cosmos DB account, and then select __Document Explorer__. From the dropdown, select the database and collection that the data is written to. You may need to select __Refresh__ before the data appears. Select the id of one of the entries to view the data in Cosmos DB. The document should contain data similar to the following:\n\n```json\n{\n  \"trip\": {\n    \"fare_amount\": \"14.5\",\n    \"pickup_longitude\": \"-73.988777160644531\",\n    \"lpep_dropoff_datetime\": \"2016-01-01T00:43:11.000\",\n    \"lpep_pickup_datetime\": \"2016-01-01T00:28:24.000\",\n    \"passenger_count\": \"2\",\n    \"vendorid\": \"2\",\n    \"tolls_amount\": \"0\",\n    \"dropoff_latitude\": \"40.729816436767578\",\n    \"improvement_surcharge\": \"0.3\",\n    \"trip_distance\": \"3.66\",\n    \"dropoff_longitude\": \"-73.996437072753906\",\n    \"payment_type\": \"2\",\n    \"store_and_fwd_flag\": \"N\",\n    \"trip_type\": \"1\",\n    \"ratecodeid\": \"1\",\n    \"total_amount\": \"15.8\",\n    \"pickup_latitude\": \"40.690895080566406\",\n    \"extra\": \"0.5\",\n    \"tip_amount\": \"0\",\n    \"mta_tax\": \"0.5\"\n  },\n  \"id\": \"abfe6ff1-51a7-46a6-9600-1c330166cf12\"\n}\n```", "cell_type": "markdown", "metadata": {"collapsed": true}}, {"execution_count": null, "cell_type": "code", "source": "", "outputs": [], "metadata": {"collapsed": true}}], "nbformat": 4, "metadata": {"kernelspec": {"display_name": "Spark", "name": "sparkkernel", "language": ""}, "language_info": {"mimetype": "text/x-scala", "pygments_lexer": "scala", "name": "scala", "codemirror_mode": "text/x-scala"}}}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Stream data to from Kafka to Cosmos DB\n",
+    "\n",
+    "This notebook uses Spark Structured Streaming to retrieve data from Kafka on HDInsight and store it into Azure Cosmos DB. It uses the [Azure CosmosDB Spark Connector](https://github.com/Azure/azure-cosmosdb-spark) to write to a Cosmos DB SQL API database. For more information on using the connector, see [https://github.com/Azure/azure-cosmosdb-spark](https://github.com/Azure/azure-cosmosdb-spark)\n",
+    "\n",
+    "## To use this notebook\n",
+    "\n",
+    "Jupyter Notebooks allow you to modify and run the code in this document. To run a section (known as a 'cell',) select it and then use CTRL + ENTER, or select the play button on the toolbar above. Note that each section already has some example output beneath it, so you can see what the results of running a cell will look like.\n",
+    "\n",
+    "NOTE: You must run each cell in order, from top to bottom. Running cells out of order can result in an error.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "* An Azure Virtual Network\n",
+    "* A Spark on HDInsight 4.0 cluster, inside the virtual network\n",
+    "* A Kafka on HDInsight 4.0 cluster, inside the virtual network\n",
+    "* A Cosmos DB SQL API database\n",
+    "\n",
+    "## Load packages\n",
+    "\n",
+    "Run the next cell to load the packages used by this notebook:\n",
+    "\n",
+    "* spark-sql-kafka-0-10_2.11, version 2.2.0 - Used to read from Kafka.\n",
+    "* azure-cosmosdb-spark_2.4.0_2.11, version 3.7.0 - The Spark connector used to communicate with Azure Cosmos DB.\n",
+    "* azure-documentdb, version 2.6.4 - The DocumentDB SDK. This is used by the connector to communicate with Cosmos DB."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%%configure -f\n",
+    "{\n",
+    "    \"name\":\"Spark-to-Cosmos_DB_Connector\", \n",
+    "    \"executorMemory\": \"8G\", \n",
+    "    \"executorCores\": 2, \n",
+    "    \"numExecutors\":9,\n",
+    "    \"driverMemory\" : \"2G\",\n",
+    "    \"conf\": {\n",
+    "        \"spark.jars.packages\": \"org.apache.spark:spark-sql-kafka-0-10_2.11:2.2.0,com.microsoft.azure:azure-cosmosdb-spark_2.4.0_2.11:3.7.0,com.microsoft.azure:azure-documentdb:2.6.4\", \n",
+    "        \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.11\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Set the Kafka broker hosts information\n",
+    "\n",
+    "In the next cell, replace YOUR_KAFKA_BROKER_HOSTS with the broker hosts for your Kafka cluster. This is used to write data to the Kafka cluster. To get the broker host information, use one of the following methods:\n",
+    "\n",
+    "* From Bash or other Unix shell:\n",
+    "\n",
+    "    ```bash\n",
+    "CLUSTERNAME='the name of your HDInsight cluster'\n",
+    "PASSWORD='the password for your cluster login account'\n",
+    "curl -u admin:$PASSWORD -G \"https://$CLUSTERNAME.azurehdinsight.net/api/v1/clusters/$CLUSTERNAME/services/KAFKA/components/KAFKA_BROKER\" | jq -r '[\"\\(.host_components[].HostRoles.host_name):9092\"] | join(\",\")' | cut -d',' -f1,2\n",
+    "    ```\n",
+    "\n",
+    "* From Azure Powershell:\n",
+    "\n",
+    "    ```powershell\n",
+    "$creds = Get-Credential -UserName \"admin\" -Message \"Enter the HDInsight login\"\n",
+    "$clusterName = Read-Host -Prompt \"Enter the Kafka cluster name\"\n",
+    "$resp = Invoke-WebRequest -Uri \"https://$clusterName.azurehdinsight.net/api/v1/clusters/$clusterName/services/KAFKA/components/KAFKA_BROKER\" `\n",
+    "  -Credential $creds `\n",
+    "  -UseBasicParsing\n",
+    "$respObj = ConvertFrom-Json $resp.Content\n",
+    "$brokerHosts = $respObj.host_components.HostRoles.host_name[0..1]\n",
+    "($brokerHosts -join \":9092,\") + \":9092\"\n",
+    "    ```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "// The Kafka broker hosts and topic used to read to Kafka\n",
+    "val kafkaBrokers=\"YOUR_BROKER_HOSTS\"\n",
+    "val kafkaTopic=\"tripdata\"\n",
+    "\n",
+    "println(\"broker and topic set.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Configure the Cosmos DB connection information\n",
+    "\n",
+    "In the following cell, you must provide the information used to connect to your Cosmos DB. Use the information in [Create a document database using Java and the Azure portal](https://docs.microsoft.com/en-us/azure/cosmos-db/create-sql-api-java) to create a database and collection, then retrieve the endpoint, master key, and preferred region information.\n",
+    "\n",
+    "__NOTE__: When following the steps in [Create a document database using Java and the Azure portal](https://docs.microsoft.com/en-us/azure/cosmos-db/create-sql-api-java), you do not need to add sample data to the collection or build the code. You only need to create the database, collection, and retrieve the connection information.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "// Import Necessary Libraries\n",
+    "import org.joda.time._\n",
+    "import org.joda.time.format._\n",
+    "\n",
+    "// Current version of the connector\n",
+    "import com.microsoft.azure.cosmosdb.spark.schema._\n",
+    "import com.microsoft.azure.cosmosdb.spark._\n",
+    "import com.microsoft.azure.cosmosdb.spark.streaming.CosmosDBSinkProvider\n",
+    "import com.microsoft.azure.cosmosdb.spark.config.Config\n",
+    "\n",
+    "var configMap = Map(\n",
+    "    \"Endpoint\" -> \"YOUR_COSMOSDB_ENDPOINT\",\n",
+    "    \"Masterkey\" -> \"YOUR_MASTER_KEY\",\n",
+    "    \"Database\" -> \"kafkadata\",\n",
+    "    // use a ';' to delimit multiple regions\n",
+    "    \"PreferredRegions\" -> \"West US;\",\n",
+    "    \"Collection\" -> \"kafkacollection\"\n",
+    ")\n",
+    "\n",
+    "println(\"Cosmos DB configuration set.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Define the schema and source stream\n",
+    "\n",
+    "The following cell creates the stream that reads from Kafka. Data read from Kafka contains several columns. In this case, we only use the `value` column, as it contains the taxi trip data written by the other notebook. To make this data easier to work with, a schema is applied."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "// Import bits useed for declaring schemas and working with JSON data\n",
+    "import org.apache.spark.sql._\n",
+    "import org.apache.spark.sql.types._\n",
+    "import org.apache.spark.sql.functions._\n",
+    "\n",
+    "// Define a schema for the data\n",
+    "val schema = (new StructType).add(\"dropoff_latitude\", StringType).add(\"dropoff_longitude\", StringType).add(\"extra\", StringType).add(\"fare_amount\", StringType).add(\"improvement_surcharge\", StringType).add(\"lpep_dropoff_datetime\", StringType).add(\"lpep_pickup_datetime\", StringType).add(\"mta_tax\", StringType).add(\"passenger_count\", StringType).add(\"payment_type\", StringType).add(\"pickup_latitude\", StringType).add(\"pickup_longitude\", StringType).add(\"ratecodeid\", StringType).add(\"store_and_fwd_flag\", StringType).add(\"tip_amount\", StringType).add(\"tolls_amount\", StringType).add(\"total_amount\", StringType).add(\"trip_distance\", StringType).add(\"trip_type\", StringType).add(\"vendorid\", StringType)\n",
+    "// Reproduced here for readability\n",
+    "//val schema = (new StructType)\n",
+    "//   .add(\"dropoff_latitude\", StringType)\n",
+    "//   .add(\"dropoff_longitude\", StringType)\n",
+    "//   .add(\"extra\", StringType)\n",
+    "//   .add(\"fare_amount\", StringType)\n",
+    "//   .add(\"improvement_surcharge\", StringType)\n",
+    "//   .add(\"lpep_dropoff_datetime\", StringType)\n",
+    "//   .add(\"lpep_pickup_datetime\", StringType)\n",
+    "//   .add(\"mta_tax\", StringType)\n",
+    "//   .add(\"passenger_count\", StringType)\n",
+    "//   .add(\"payment_type\", StringType)\n",
+    "//   .add(\"pickup_latitude\", StringType)\n",
+    "//   .add(\"pickup_longitude\", StringType)\n",
+    "//   .add(\"ratecodeid\", StringType)\n",
+    "//   .add(\"store_and_fwd_flag\", StringType)\n",
+    "//   .add(\"tip_amount\", StringType)\n",
+    "//   .add(\"tolls_amount\", StringType)\n",
+    "//   .add(\"total_amount\", StringType)\n",
+    "//   .add(\"trip_distance\", StringType)\n",
+    "//   .add(\"trip_type\", StringType)\n",
+    "//   .add(\"vendorid\", StringType)\n",
+    "\n",
+    "// Read from the Kafka stream source\n",
+    "val kafka = spark.readStream.format(\"kafka\").option(\"kafka.bootstrap.servers\", kafkaBrokers).option(\"subscribe\", kafkaTopic).option(\"startingOffsets\",\"earliest\").load()\n",
+    "\n",
+    "// Select the value of the Kafka message and apply the trip schema to it\n",
+    "val taxiData = kafka.select(\n",
+    "    from_json(col(\"value\").cast(\"string\"), schema) as \"trip\")\n",
+    "\n",
+    "// The output of this cell is similar to the following value:\n",
+    "// taxiData: org.apache.spark.sql.DataFrame = [trip: struct<dropoff_latitude: string, dropoff_longitude: string ... 18 more fields>]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Write the data to Cosmos DB\n",
+    "\n",
+    "The following cell selects the trip data from the stream and writes it to Cosmos DB. This is the data structure that was created in the previous cell by applying a schema to the value data retrieved from kafka.\n",
+    "\n",
+    "This stream only runs for 10 seconds (10000ms). Please make sure that the Stream-taxi-data-to-Kafka notebook is actively streaming data into Kafka during this time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "taxiData.select(\"trip\").writeStream.format(classOf[CosmosDBSinkProvider].getName).outputMode(\"append\").options(configMap).option(\"checkpointLocation\", \"cosmoscheckpointlocation\").start.awaitTermination(10000)\n",
+    "println(\"Stream finished.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## To verify that data is in Cosmos DB\n",
+    "\n",
+    "In the [Azure portal](https://portal.azure.com), select your Cosmos DB account, and then select __Document Explorer__. From the dropdown, select the database and collection that the data is written to. You may need to select __Refresh__ before the data appears. Select the id of one of the entries to view the data in Cosmos DB. The document should contain data similar to the following:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"trip\": {\n",
+    "    \"fare_amount\": \"14.5\",\n",
+    "    \"pickup_longitude\": \"-73.988777160644531\",\n",
+    "    \"lpep_dropoff_datetime\": \"2016-01-01T00:43:11.000\",\n",
+    "    \"lpep_pickup_datetime\": \"2016-01-01T00:28:24.000\",\n",
+    "    \"passenger_count\": \"2\",\n",
+    "    \"vendorid\": \"2\",\n",
+    "    \"tolls_amount\": \"0\",\n",
+    "    \"dropoff_latitude\": \"40.729816436767578\",\n",
+    "    \"improvement_surcharge\": \"0.3\",\n",
+    "    \"trip_distance\": \"3.66\",\n",
+    "    \"dropoff_longitude\": \"-73.996437072753906\",\n",
+    "    \"payment_type\": \"2\",\n",
+    "    \"store_and_fwd_flag\": \"N\",\n",
+    "    \"trip_type\": \"1\",\n",
+    "    \"ratecodeid\": \"1\",\n",
+    "    \"total_amount\": \"15.8\",\n",
+    "    \"pickup_latitude\": \"40.690895080566406\",\n",
+    "    \"extra\": \"0.5\",\n",
+    "    \"tip_amount\": \"0\",\n",
+    "    \"mta_tax\": \"0.5\"\n",
+    "  },\n",
+    "  \"id\": \"abfe6ff1-51a7-46a6-9600-1c330166cf12\"\n",
+    "}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark | Scala",
+   "language": "",
+   "name": "sparkkernel"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-scala",
+   "mimetype": "text/x-scala",
+   "name": "scala",
+   "pygments_lexer": "scala"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Stream-taxi-data-to-Kafka.ipynb
+++ b/Stream-taxi-data-to-Kafka.ipynb
@@ -1,1 +1,272 @@
-{"cells":[{"cell_type":"markdown","metadata":{},"source":["# Retrive taxi trip data for New York city\n","\n","This notebook retrieves data on taxi trips, which is provided by the New York City. The data is stored into Kafka, and then used by the other notebook in this project (Stream-data-from-Kafka-to-Cosmos-DB) to demonstrate how to write data into Cosmos.\n","\n","The data set used by this notebook is from [2016 Green Taxi Trip Data](https://data.cityofnewyork.us/Transportation/2016-Green-Taxi-Trip-Data/hvrh-b6nb).\n","\n","## To use this notebook\n","\n","Jupyter Notebooks allow you to modify and run the code in this document. To run a section (known as a 'cell',) select it and then use CTRL + ENTER, or select the play button on the toolbar above. Note that each section already has some example output beneath it, so you can see what the results of running a cell will look like.\n","\n","NOTE: You must run each cell in order, from top to bottom. Running cells out of order can result in an error.\n","\n","## Requirements\n","\n","* An Azure Virtual Network\n","* A Spark (2.2.0) on HDInsight 3.6 cluster, inside the virtual network\n","* A Kafka on HDInsight 3.6 cluster, inside the virtual network\n","\n","## Load packages\n","\n","Run the next cell to load packages used by this notebook:\n","\n","* spark-streaming-kafka-0-8_2.10, version 2.2.0 - Used to write data to Kafka.\n","* gson version 2.4 - Used for JSON parsing.\n","\n","__NOTE__: The first time you run this block, it may take a minute or longer. This happens because the Spark cluster must retrieve the packages from the Maven repository on the internet."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":false},"outputs":[],"source":["%%configure -f\n","{\n","    \"conf\": {\n","        \"spark.jars.packages\": \"org.apache.spark:spark-streaming-kafka-0-8_2.10:2.2.0,com.google.code.gson:gson:2.4\",\n","        \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.11\"\n","    }\n","}"]},{"cell_type":"markdown","metadata":{},"source":["## Create the Kafka topic\n","\n","In the next cell, you must provide the Zookeeper host information for your Kafka cluster. Use the following steps to get this information:\n","\n","* From __Bash__ or other Unix shell:\n","\n","    ```bash\n","CLUSTERNAME='the name of your HDInsight cluster'\n","PASSWORD='the password for your cluster login account'\n","curl -u admin:$PASSWORD -G https://$CLUSTERNAME.azurehdinsight.net/api/v1/clusters/$CLUSTERNAME/services/ZOOKEEPER/components/ZOOKEEPER_SERVER| grep -i host_name | awk 'NR==1{print $NF,\":2181\"}'|tr -d '\"'|tr -d ' '\n","    ```\n","\n","* From __Azure PowerShell__:\n","\n","    ```powershell\n","$creds = Get-Credential -UserName \"admin\" -Message \"Enter the HDInsight login\"\n","$clusterName = Read-Host -Prompt \"Enter the Kafka cluster name\"\n","$resp = Invoke-WebRequest -Uri \"https://$clusterName.azurehdinsight.net/api/v1/clusters/$clusterName/services/ZOOKEEPER/components/ZOOKEEPER_SERVER\" `\n","    -Credential $creds `\n","    -UseBasicParsing\n","$respObj = ConvertFrom-Json $resp.Content\n","$zkHosts = $respObj.host_components.HostRoles.host_name[0..1]\n","($zkHosts -join \":2181,\") + \":2181\"\n","    ````\n","\n","The return value is similar to the following example:\n","\n","`zk0-kafka.ztgnbfvxu2mudoa5h5zzc1uncg.cx.internal.cloudapp.net:2181,zk1-kafka.ztgnbfvxu2mudoa5h5zzc1uncg.cx.internal.cloudapp.net:2181`\n","\n","Replace the `YOUR_ZOOKEEPER_HOSTS` in the next cell with the returned value, and then run the cell"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":false},"outputs":[],"source":["%%bash \n","/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --create --replication-factor 3 --partitions 8 --topic tripdata --zookeeper 'YOUR_ZOOKEEPER_HOSTS'"]},{"cell_type":"markdown","metadata":{},"source":["## Retrieve data on taxi trips\n","\n","Run the next cell to load data on taxi trips in New York City."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":false},"outputs":[],"source":["// Load the data from the New York City Taxi data REST API for 2016 Green Taxi Trip Data\n","val url=\"https://data.cityofnewyork.us/resource/pqfs-mqru.json\"\n","val result = scala.io.Source.fromURL(url).mkString\n","\n","// Since the REST API returns an array of items,\n","// it's easier to use as an array than deal with streaming\n","import com.google.gson.Gson\n","val gson = new Gson()\n","val jsonDataArray = gson.fromJson(result, classOf[Array[Object]])\n","\n","println(\"Retrieved \" + jsonDataArray.length + \" rows of Taxi data.\")"]},{"cell_type":"markdown","metadata":{},"source":["## Set the Kafka broker hosts information\n","\n","In the next cell, replace YOUR_KAFKA_BROKER_HOSTS with the broker hosts for your Kafka cluster. This is used to write data to the Kafka cluster. To get the broker host information, use one of the following methods:\n","\n","* From Bash or other Unix shell:\n","\n","    ```bash\n","CLUSTERNAME='the name of your HDInsight cluster'\n","PASSWORD='the password for your cluster login account'\n","curl -u admin:$PASSWORD -G https://$CLUSTERNAME.azurehdinsight.net/api/v1/clusters/$CLUSTERNAME/services/KAFKA/components/KAFKA_BROKER| grep -i host_name | awk 'NR==1{print $NF,\":9092\"}'|tr -d '\"'|tr -d ' '\n","    ```\n","\n","* From Azure Powershell:\n","\n","    ```powershell\n","$creds = Get-Credential -UserName \"admin\" -Message \"Enter the HDInsight login\"\n","$clusterName = Read-Host -Prompt \"Enter the Kafka cluster name\"\n","$resp = Invoke-WebRequest -Uri \"https://$clusterName.azurehdinsight.net/api/v1/clusters/$clusterName/services/KAFKA/components/KAFKA_BROKER\" `\n","  -Credential $creds `\n","  -UseBasicParsing\n","$respObj = ConvertFrom-Json $resp.Content\n","$brokerHosts = $respObj.host_components.HostRoles.host_name[0..1]\n","($brokerHosts -join \":9092,\") + \":9092\"\n","    ```"]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":true},"outputs":[],"source":["// The Kafka broker hosts and topic used to write to Kafka\n","val kafkaBrokers=\"YOUR_BROKER_HOSTS\"\n","val kafkaTopic=\"tripdata\""]},{"cell_type":"markdown","metadata":{},"source":["## Send the data to Kafka\n","\n","Run the following cell to begin streaming data to Kafka. There is a delay of 1 second (1000ms) after each send, so this cell will stay active several minutes. This provides you the time needed to load the other notebook and run the cells in it while data is flowing into Kafka."]},{"cell_type":"code","execution_count":null,"metadata":{"collapsed":false},"outputs":[],"source":["// Import classes used to write to Kafka via a producer\n","import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}\n","import java.util.HashMap\n","\n","// Create the Kafka producer\n","val producerProperties = new HashMap[String, Object]()\n","producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBrokers)\n","producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,\n","                           \"org.apache.kafka.common.serialization.StringSerializer\")\n","producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,\n","                           \"org.apache.kafka.common.serialization.StringSerializer\")\n","val producer = new KafkaProducer[String, String](producerProperties)\n","\n","// Iterate over data and emit to Kafka\n","jsonDataArray.foreach { row =>\n","                // Get the row as a JSON string\n","                val jsonData = gson.toJson(row)\n","                // Create the message for Kafka\n","                val message = new ProducerRecord[String, String](kafkaTopic, null, jsonData)\n","                // Send the message\n","                producer.send(message)\n","                // Sleep a bit between sends to simulate streaming data\n","                Thread.sleep(1000)\n","             }\n","producer.close()\n","println(\"Finished writting to Kafka\")"]},{"cell_type":"markdown","metadata":{"collapsed":false},"source":["## Load and run the Stream-data-from-Kafka-to-Cosmos-DB notebook\n","\n","While the previous cell is active, load the other notebook in this project (Stream-data-from-Kafka-to-Cosmos-DB) and follow the steps in it."]}],"metadata":{"kernelspec":{"display_name":"Spark","language":"","name":"sparkkernel"},"language_info":{"codemirror_mode":"text/x-scala","mimetype":"text/x-scala","name":"scala","pygments_lexer":"scala"}},"nbformat":4,"nbformat_minor":2}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Retrive taxi trip data for New York city\n",
+    "\n",
+    "This notebook retrieves data on taxi trips, which is provided by the New York City. The data is stored into Kafka, and then used by the other notebook in this project (Stream-data-from-Kafka-to-Cosmos-DB) to demonstrate how to write data into Cosmos.\n",
+    "\n",
+    "The data set used by this notebook is from [2016 Green Taxi Trip Data](https://data.cityofnewyork.us/Transportation/2016-Green-Taxi-Trip-Data/hvrh-b6nb).\n",
+    "\n",
+    "## To use this notebook\n",
+    "\n",
+    "Jupyter Notebooks allow you to modify and run the code in this document. To run a section (known as a 'cell',) select it and then use CTRL + ENTER, or select the play button on the toolbar above. Note that each section already has some example output beneath it, so you can see what the results of running a cell will look like.\n",
+    "\n",
+    "NOTE: You must run each cell in order, from top to bottom. Running cells out of order can result in an error.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "* An Azure Virtual Network\n",
+    "* A Spark (2.4) on HDInsight 4.0 cluster, inside the virtual network\n",
+    "* A Kafka on HDInsight 4.0 cluster, inside the virtual network\n",
+    "\n",
+    "## Load packages\n",
+    "\n",
+    "Run the next cell to load packages used by this notebook:\n",
+    "\n",
+    "* spark-streaming-kafka-0-8_2.10, version 2.2.0 - Used to write data to Kafka.\n",
+    "* gson version 2.4 - Used for JSON parsing.\n",
+    "\n",
+    "__NOTE__: The first time you run this block, it may take a minute or longer. This happens because the Spark cluster must retrieve the packages from the Maven repository on the internet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%%configure -f\n",
+    "{\n",
+    "    \"conf\": {\n",
+    "        \"spark.jars.packages\": \"org.apache.spark:spark-streaming-kafka-0-8_2.10:2.2.0,com.google.code.gson:gson:2.4\",\n",
+    "        \"spark.jars.excludes\": \"org.scala-lang:scala-reflect,org.apache.spark:spark-tags_2.11\"\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Create the Kafka topic\n",
+    "\n",
+    "In the next cell, you must provide the Zookeeper host information for your Kafka cluster. Use the following steps to get this information:\n",
+    "\n",
+    "* From __Bash__ or other Unix shell:\n",
+    "\n",
+    "    ```bash\n",
+    "CLUSTERNAME='the name of your HDInsight cluster'\n",
+    "PASSWORD='the password for your cluster login account'\n",
+    "curl -u admin:$PASSWORD -G https://$CLUSTERNAME.azurehdinsight.net/api/v1/clusters/$CLUSTERNAME/services/ZOOKEEPER/components/ZOOKEEPER_SERVER| grep -i host_name | awk 'NR==1{print $NF,\":2181\"}'|tr -d '\"'|tr -d ' '\n",
+    "    ```\n",
+    "\n",
+    "* From __Azure PowerShell__:\n",
+    "\n",
+    "    ```powershell\n",
+    "$creds = Get-Credential -UserName \"admin\" -Message \"Enter the HDInsight login\"\n",
+    "$clusterName = Read-Host -Prompt \"Enter the Kafka cluster name\"\n",
+    "$resp = Invoke-WebRequest -Uri \"https://$clusterName.azurehdinsight.net/api/v1/clusters/$clusterName/services/ZOOKEEPER/components/ZOOKEEPER_SERVER\" `\n",
+    "    -Credential $creds `\n",
+    "    -UseBasicParsing\n",
+    "$respObj = ConvertFrom-Json $resp.Content\n",
+    "$zkHosts = $respObj.host_components.HostRoles.host_name[0..1]\n",
+    "($zkHosts -join \":2181,\") + \":2181\"\n",
+    "    ````\n",
+    "\n",
+    "The return value is similar to the following example:\n",
+    "\n",
+    "`zk0-kafka.ztgnbfvxu2mudoa5h5zzc1uncg.cx.internal.cloudapp.net:2181,zk1-kafka.ztgnbfvxu2mudoa5h5zzc1uncg.cx.internal.cloudapp.net:2181`\n",
+    "\n",
+    "Replace the `YOUR_ZOOKEEPER_HOSTS` in the next cell with the returned value, and then run the cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "%%bash \n",
+    "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --create --replication-factor 3 --partitions 8 --topic tripdata --zookeeper 'YOUR_ZOOKEEPER_HOSTS'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Retrieve data on taxi trips\n",
+    "\n",
+    "Run the next cell to load data on taxi trips in New York City."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "// Load the data from the New York City Taxi data REST API for 2016 Green Taxi Trip Data\n",
+    "val url=\"https://data.cityofnewyork.us/resource/pqfs-mqru.json\"\n",
+    "val result = scala.io.Source.fromURL(url).mkString\n",
+    "\n",
+    "// Since the REST API returns an array of items,\n",
+    "// it's easier to use as an array than deal with streaming\n",
+    "import com.google.gson.Gson\n",
+    "val gson = new Gson()\n",
+    "val jsonDataArray = gson.fromJson(result, classOf[Array[Object]])\n",
+    "\n",
+    "println(\"Retrieved \" + jsonDataArray.length + \" rows of Taxi data.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Set the Kafka broker hosts information\n",
+    "\n",
+    "In the next cell, replace YOUR_KAFKA_BROKER_HOSTS with the broker hosts for your Kafka cluster. This is used to write data to the Kafka cluster. To get the broker host information, use one of the following methods:\n",
+    "\n",
+    "* From Bash or other Unix shell:\n",
+    "\n",
+    "    ```bash\n",
+    "CLUSTERNAME='the name of your HDInsight cluster'\n",
+    "PASSWORD='the password for your cluster login account'\n",
+    "curl -u admin:$PASSWORD -G https://$CLUSTERNAME.azurehdinsight.net/api/v1/clusters/$CLUSTERNAME/services/KAFKA/components/KAFKA_BROKER| grep -i host_name | awk 'NR==1{print $NF,\":9092\"}'|tr -d '\"'|tr -d ' '\n",
+    "    ```\n",
+    "\n",
+    "* From Azure Powershell:\n",
+    "\n",
+    "    ```powershell\n",
+    "$creds = Get-Credential -UserName \"admin\" -Message \"Enter the HDInsight login\"\n",
+    "$clusterName = Read-Host -Prompt \"Enter the Kafka cluster name\"\n",
+    "$resp = Invoke-WebRequest -Uri \"https://$clusterName.azurehdinsight.net/api/v1/clusters/$clusterName/services/KAFKA/components/KAFKA_BROKER\" `\n",
+    "  -Credential $creds `\n",
+    "  -UseBasicParsing\n",
+    "$respObj = ConvertFrom-Json $resp.Content\n",
+    "$brokerHosts = $respObj.host_components.HostRoles.host_name[0..1]\n",
+    "($brokerHosts -join \":9092,\") + \":9092\"\n",
+    "    ```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "// The Kafka broker hosts and topic used to write to Kafka\n",
+    "val kafkaBrokers=\"YOUR_BROKER_HOSTS\"\n",
+    "val kafkaTopic=\"tripdata\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Send the data to Kafka\n",
+    "\n",
+    "Run the following cell to begin streaming data to Kafka. There is a delay of 1 second (1000ms) after each send, so this cell will stay active several minutes. This provides you the time needed to load the other notebook and run the cells in it while data is flowing into Kafka."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "// Import classes used to write to Kafka via a producer\n",
+    "import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}\n",
+    "import java.util.HashMap\n",
+    "\n",
+    "// Create the Kafka producer\n",
+    "val producerProperties = new HashMap[String, Object]()\n",
+    "producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBrokers)\n",
+    "producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,\n",
+    "                           \"org.apache.kafka.common.serialization.StringSerializer\")\n",
+    "producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,\n",
+    "                           \"org.apache.kafka.common.serialization.StringSerializer\")\n",
+    "val producer = new KafkaProducer[String, String](producerProperties)\n",
+    "\n",
+    "// Iterate over data and emit to Kafka\n",
+    "jsonDataArray.foreach { row =>\n",
+    "                // Get the row as a JSON string\n",
+    "                val jsonData = gson.toJson(row)\n",
+    "                // Create the message for Kafka\n",
+    "                val message = new ProducerRecord[String, String](kafkaTopic, null, jsonData)\n",
+    "                // Send the message\n",
+    "                producer.send(message)\n",
+    "                // Sleep a bit between sends to simulate streaming data\n",
+    "                Thread.sleep(1000)\n",
+    "             }\n",
+    "producer.close()\n",
+    "println(\"Finished writting to Kafka\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "## Load and run the Stream-data-from-Kafka-to-Cosmos-DB notebook\n",
+    "\n",
+    "While the previous cell is active, load the other notebook in this project (Stream-data-from-Kafka-to-Cosmos-DB) and follow the steps in it."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Spark | Scala",
+   "language": "",
+   "name": "sparkkernel"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-scala",
+   "mimetype": "text/x-scala",
+   "name": "scala",
+   "pygments_lexer": "scala"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -2,297 +2,300 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "cosmosDBAccountName": {
-        "type": "string",
-        "metadata": {
-          "description": "The Cosmos DB account name."
-        }
-      },
-      "baseClusterName": {
-            "type": "string",
+        "cosmosDBAccountName": {
+            "type": "String",
+            "metadata": {
+                "description": "The Cosmos DB account name."
+            }
+        },
+        "baseClusterName": {
+            "type": "String",
             "metadata": {
                 "description": "The base name used to create resources; spark-basename, kafka-basename, basename-vnet, basenamestore."
             }
         },
         "clusterVersion": {
-          "type": "string",
-          "defaultValue": "3.6",
-          "metadata": {
-            "description": "The HDInsight cluster version."
-          }
+            "defaultValue": "4.0",
+            "type": "String",
+            "metadata": {
+                "description": "The HDInsight cluster version."
+            }
         },
         "clusterLoginUserName": {
-            "type": "string",
             "defaultValue": "admin",
+            "type": "String",
             "metadata": {
                 "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
             }
         },
         "clusterLoginPassword": {
-            "type": "securestring",
+            "type": "SecureString",
             "metadata": {
                 "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
             }
         },
         "sshUserName": {
-            "type": "string",
             "defaultValue": "sshuser",
+            "type": "String",
             "metadata": {
                 "description": "These credentials can be used to remotely access the cluster."
             }
         },
         "sshPassword": {
-            "type": "securestring",
+            "type": "SecureString",
             "metadata": {
                 "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
             }
         }
     },
-  "variables": {
-    "defaultApiVersion": "2015-05-01-preview",
-    "clusterApiVersion": "2015-03-01-preview",
-    "clusterWorkerNodeCount": "3",
-    "disksPerWorkerNode": "2",
-    "virtualNetworkName": "[concat(parameters('baseClusterName'),'-network')]",
-    "clusterStorageAccountName": "[concat(parameters('baseClusterName'),'store')]",
-    "kafkaClusterName": "[concat('kafka-', parameters('baseClusterName'))]",
-    "sparkClusterName": "[concat('spark-', parameters('baseClusterName'))]",
-    "virtualNetworkAddressSpace": "10.0.0.0/16",
-    "defaultSubnetName": "default",
-    "defaultSubnetAddressRange": "10.0.0.0/24"
-  },
-  "resources": [
-    {
-      "apiVersion": "2015-04-08",
-      "type": "Microsoft.DocumentDB/databaseAccounts",
-      "kind": "GlobalDocumentDB",
-      "name": "[parameters('cosmosDBAccountName')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "databaseAccountOfferType": "Standard",
-        "name": "[parameters('cosmosDBAccountName')]"
-      },
-      "tags": {
-        "defaultExperience": "DocumentDB"
-      }
+    "variables": {
+        "defaultApiVersion": "2015-05-01-preview",
+        "clusterApiVersion": "2015-03-01-preview",
+        "clusterWorkerNodeCount": "3",
+        "disksPerWorkerNode": "2",
+        "virtualNetworkName": "[concat(parameters('baseClusterName'),'-network')]",
+        "clusterStorageAccountName": "[concat(parameters('baseClusterName'),'store')]",
+        "kafkaClusterName": "[concat('kafka-', parameters('baseClusterName'))]",
+        "sparkClusterName": "[concat('spark-', parameters('baseClusterName'))]",
+        "virtualNetworkAddressSpace": "10.0.0.0/16",
+        "defaultSubnetName": "default",
+        "defaultSubnetAddressRange": "10.0.0.0/24"
     },
-    {
-      "name": "[variables('virtualNetworkName')]",
-      "type": "Microsoft.Network/virtualNetworks",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('defaultApiVersion')]",
-      "dependsOn": [ ],
-      "tags": { },
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('virtualnetworkaddressSpace')]"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[variables('defaultSubnetName')]",
+    "resources": [
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts",
+            "apiVersion": "2015-04-08",
+            "name": "[parameters('cosmosDBAccountName')]",
+            "location": "[resourceGroup().location]",
+            "tags": {
+                "defaultExperience": "DocumentDB"
+            },
+            "kind": "GlobalDocumentDB",
             "properties": {
-              "addressPrefix": "[variables('defaultSubnetAddressRange')]"
+                "databaseAccountOfferType": "Standard",
+                "name": "[parameters('cosmosDBAccountName')]"
             }
-          }
-        ]
-      }
-    },
-    {
-      "name": "[variables('clusterStorageAccountName')]",
-      "type": "Microsoft.Storage/storageAccounts",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('defaultApiVersion')]",
-      "dependsOn": [ ],
-      "tags": { },
-      "properties": {
-        "accountType": "Standard_LRS"
-      }
-    },
-    {
-      "name": "[variables('kafkaClusterName')]",
-      "type": "Microsoft.HDInsight/clusters",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('clusterApiVersion')]",
-      "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
-      ],
-      "tags": { },
-      "properties": {
-        "clusterVersion": "[parameters('clusterVersion')]",
-        "osType": "Linux",
-        "clusterDefinition": {
-          "kind": "kafka",
-          "configurations": {
-            "gateway": {
-              "restAuthCredential.isEnabled": true,
-              "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
-              "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
-            }
-          }
         },
-        "storageProfile": {
-          "storageaccounts": [
-            {
-              "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
-              "isDefault": true,
-              "container": "[variables('kafkaClusterName')]",
-              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "apiVersion": "[variables('defaultApiVersion')]",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [],
+            "tags": {},
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('virtualnetworkaddressSpace')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('defaultSubnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('defaultSubnetAddressRange')]"
+                        }
+                    }
+                ]
             }
-          ]
         },
-        "computeProfile": {
-          "roles": [
-            {
-              "name": "headnode",
-              "targetInstanceCount": "2",
-              "hardwareProfile": {
-                "vmSize": "Large"
-              },
-              "osProfile": {
-                "linuxOperatingSystemProfile": {
-                  "username": "[parameters('sshUserName')]",
-                  "password": "[parameters('sshPassword')]"
-                }
-              },
-              "virtualNetworkProfile": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
-              }
-            },
-            {
-              "name": "workernode",
-              "targetInstanceCount": "[variables('clusterWorkerNodeCount')]",
-              "hardwareProfile": {
-                "vmSize": "Large"
-              },
-              "dataDisksGroups": [
-                {
-                  "disksPerNode": "[variables('disksPerWorkerNode')]"
-                }
-              ],
-              "osProfile": {
-                "linuxOperatingSystemProfile": {
-                  "username": "[parameters('sshUserName')]",
-                  "password": "[parameters('sshPassword')]"
-                }
-              },
-              "virtualNetworkProfile": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
-              }
-            },
-            {
-              "name": "zookeepernode",
-              "targetInstanceCount": "3",
-              "hardwareProfile": {
-                "vmSize": "Medium"
-              },
-              "osProfile": {
-                "linuxOperatingSystemProfile": {
-                  "username": "[parameters('sshUserName')]",
-                  "password": "[parameters('sshPassword')]"
-                }
-              },
-              "virtualNetworkProfile": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
-              }
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "[variables('defaultApiVersion')]",
+            "name": "[variables('clusterStorageAccountName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [],
+            "tags": {},
+            "properties": {
+                "accountType": "Standard_LRS"
             }
-          ]
+        },
+        {
+            "type": "Microsoft.HDInsight/clusters",
+            "apiVersion": "[variables('clusterApiVersion')]",
+            "name": "[variables('kafkaClusterName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
+            ],
+            "tags": {},
+            "properties": {
+                "clusterVersion": "[parameters('clusterVersion')]",
+                "osType": "Linux",
+                "clusterDefinition": {
+                    "kind": "kafka",
+                    "componentVersion": {
+                        "Kafka": "2.1"
+                    },
+                    "configurations": {
+                        "gateway": {
+                            "restAuthCredential.isEnabled": true,
+                            "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
+                            "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
+                        }
+                    }
+                },
+                "storageProfile": {
+                    "storageaccounts": [
+                        {
+                            "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
+                            "isDefault": true,
+                            "container": "[variables('kafkaClusterName')]",
+                            "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+                        }
+                    ]
+                },
+                "computeProfile": {
+                    "roles": [
+                        {
+                            "name": "headnode",
+                            "targetInstanceCount": "2",
+                            "hardwareProfile": {
+                                "vmSize": "Large"
+                            },
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sshUserName')]",
+                                    "password": "[parameters('sshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+                                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
+                            }
+                        },
+                        {
+                            "name": "workernode",
+                            "targetInstanceCount": "[variables('clusterWorkerNodeCount')]",
+                            "hardwareProfile": {
+                                "vmSize": "Large"
+                            },
+                            "dataDisksGroups": [
+                                {
+                                    "disksPerNode": "[variables('disksPerWorkerNode')]"
+                                }
+                            ],
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sshUserName')]",
+                                    "password": "[parameters('sshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+                                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
+                            }
+                        },
+                        {
+                            "name": "zookeepernode",
+                            "targetInstanceCount": "3",
+                            "hardwareProfile": {
+                                "vmSize": "Medium"
+                            },
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sshUserName')]",
+                                    "password": "[parameters('sshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+                                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.HDInsight/clusters",
+            "apiVersion": "[variables('clusterApiVersion')]",
+            "name": "[variables('sparkClusterName')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
+            ],
+            "tags": {},
+            "properties": {
+                "clusterVersion": "[parameters('clusterVersion')]",
+                "osType": "Linux",
+                "clusterDefinition": {
+                    "kind": "Spark",
+                    "componentVersion": {
+                        "Spark": "2.4"
+                    },
+                    "configurations": {
+                        "gateway": {
+                            "restAuthCredential.isEnabled": true,
+                            "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
+                            "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
+                        }
+                    }
+                },
+                "storageProfile": {
+                    "storageaccounts": [
+                        {
+                            "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
+                            "isDefault": true,
+                            "container": "[variables('sparkClusterName')]",
+                            "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+                        }
+                    ]
+                },
+                "computeProfile": {
+                    "roles": [
+                        {
+                            "name": "headnode",
+                            "targetInstanceCount": "2",
+                            "hardwareProfile": {
+                                "vmSize": "Standard_E8_v3"
+                            },
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sshUserName')]",
+                                    "password": "[parameters('sshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+                                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
+                            }
+                        },
+                        {
+                            "name": "workernode",
+                            "targetInstanceCount": "[variables('clusterWorkerNodeCount')]",
+                            "hardwareProfile": {
+                                "vmSize": "Standard_E8_v3"
+                            },
+                            "osProfile": {
+                                "linuxOperatingSystemProfile": {
+                                    "username": "[parameters('sshUserName')]",
+                                    "password": "[parameters('sshPassword')]"
+                                }
+                            },
+                            "virtualNetworkProfile": {
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+                                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
+                            }
+                        }
+                    ]
+                }
+            }
         }
-      }
-    },
-    {
-      "name": "[variables('sparkClusterName')]",
-      "type": "Microsoft.HDInsight/clusters",
-      "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('clusterApiVersion')]",
-      "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
-      ],
-      "tags": { },
-      "properties": {
-        "clusterVersion": "[parameters('clusterVersion')]",
-        "osType": "Linux",
-        "clusterDefinition": {
-          "kind": "Spark",
-          "componentVersion": {
-            "Spark": "2.2"
-          },
-          "configurations": {
-            "gateway": {
-              "restAuthCredential.isEnabled": true,
-              "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
-              "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
-            }
-          }
-        },
-        "storageProfile": {
-          "storageaccounts": [
-            {
-              "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
-              "isDefault": true,
-              "container": "[variables('sparkClusterName')]",
-              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
-            }
-          ]
-        },
-        "computeProfile": {
-          "roles": [
-            {
-              "name": "headnode",
-              "targetInstanceCount": "2",
-              "hardwareProfile": {
-                "vmSize": "Standard_D3"
-              },
-              "osProfile": {
-                "linuxOperatingSystemProfile": {
-                  "username": "[parameters('sshUserName')]",
-                  "password": "[parameters('sshPassword')]"
-                }
-              },
-              "virtualNetworkProfile": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
-              }
-            },
-            {
-              "name": "workernode",
-              "targetInstanceCount": "[variables('clusterWorkerNodeCount')]",
-              "hardwareProfile": {
-                "vmSize": "Standard_D3"
-              },
-              "osProfile": {
-                "linuxOperatingSystemProfile": {
-                  "username": "[parameters('sshUserName')]",
-                  "password": "[parameters('sshPassword')]"
-                }
-              },
-              "virtualNetworkProfile": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), '/subnets/', variables('defaultSubnetName'))]"
-              }
-            }
-          ]
-        }
-      }
-    }
-  ],
+    ],
     "outputs": {
         "vnet": {
-            "type": "object",
+            "type": "Object",
             "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')))]"
         },
         "kafkaCluster": {
-            "type": "object",
+            "type": "Object",
             "value": "[reference(resourceId('Microsoft.HDInsight/clusters',variables('kafkaClusterName')))]"
         },
         "sparkCluster": {
-            "type": "object",
+            "type": "Object",
             "value": "[reference(resourceId('Microsoft.HDInsight/clusters',variables('sparkClusterName')))]"
         }
     }


### PR DESCRIPTION
## Purpose
Sample in this repo is using HDInsight 3.6 version. But HDInsight 3.6 Support is ended as of October 1st, 2022. Changes made in this PR updates ; 
* Texts in markdown files as well as notebooks
* ARM template file to use HDInsight 4.0 version of Spark 2.4 and Kafka 2.1 clusters , instead of HDInsight 3.6 version of Spark 2.1 and Kafka 1.0 cluster.
* Jupyter notebooks to use updated Spark jars

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe:
Product version upgrade (from HDInsight 3.6 to 4.0)
```

## How to Test
*  Follow the instructions in README.MD

## Other Information
<!-- Add any other helpful information that may be needed here. -->